### PR TITLE
Reclassify OVERLOAD and COMMLOST from `critical` to `warning`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,10 @@ Single bash script. No build system, no dependencies beyond `apcupsd`/`apcaccess
 
 **Status handling:** The apcupsd STATUS field can contain multiple space-separated flags (e.g., `ONLINE OVERLOAD`). The script uses priority-based pattern matching to handle these compound statuses:
 
-1. **Critical states** (highest priority): `SHUTTING DOWN`, `COMMLOST`, `LOWBATT`, `REPLACEBATT`, `NOBATT`, `OVERLOAD`
-2. **Power states**: `ONBATT` (discharging), `ONLINE` (charging)
-3. **Informational flags** (shown in tooltip): `CAL`, `TRIM`, `BOOST`, `SLAVE`, `SLAVEDOWN`
+1. **Critical states** (highest priority): `SHUTTING DOWN`, `LOWBATT`, `REPLACEBATT`, `NOBATT` — UPS hardware failing or shutdown imminent
+2. **Warning states**: `COMMLOST`, `OVERLOAD` — attention needed, but UPS hardware is healthy
+3. **Power states**: `ONBATT` (discharging), `ONLINE` (charging)
+4. **Informational flags** (shown in tooltip): `CAL`, `TRIM`, `BOOST`, `SLAVE`, `SLAVEDOWN`
 
 Each state maps to an icon set (charging vs discharging Nerd Font battery icons, indexed by charge level in 10% steps) and a CSS class.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Icons are configured entirely in your Waybar config via [`format-icons`](https:/
 |---|---|---|
 | `charging` | UPS online / on mains | Array — picked by percentage (0-100%) |
 | `discharging` | UPS on battery | Array — picked by percentage (0-100%) |
-| `alert` | Error states (LOWBATT, OVERLOAD, etc.) | Single icon |
+| `alert` | Critical/warning states (LOWBATT, OVERLOAD, etc.) | Single icon |
 | `unknown` | Communication lost / unknown status | Single icon |
 
 ### Using different icons
@@ -178,25 +178,30 @@ The script outputs JSON with these fields:
 |---|---|
 | `online` | On mains power |
 | `on-battery` | On battery, charge > 50% |
-| `warning` | On battery, charge 20-50% |
-| `critical` | On battery charge < 20%, or any error state |
+| `warning` | On battery charge 20-50%; or COMMLOST / OVERLOAD |
+| `critical` | On battery charge < 20%; or LOWBATT, REPLACEBATT, NOBATT, SHUTTING DOWN |
 
 ### Status Flags
 
 The apcupsd STATUS field can contain multiple space-separated flags (e.g., `ONLINE OVERLOAD`). The script uses priority-based pattern matching to handle compound statuses correctly.
 
-**Critical states** (highest priority):
+**Critical states** (highest priority — UPS hardware failing or shutdown imminent):
 
 | Flag | Meaning |
 |---|---|
 | SHUTTING DOWN | System is shutting down |
-| COMMLOST | Lost communication with UPS |
 | LOWBATT | Low battery, shutdown imminent |
 | REPLACEBATT | Battery needs replacement |
 | NOBATT | No battery detected |
-| OVERLOAD | UPS load exceeds capacity |
 
-**Power states** (checked if no critical state):
+**Warning states** (UPS hardware healthy, but attention needed):
+
+| Flag | Meaning |
+|---|---|
+| COMMLOST | Lost communication with UPS device (cable/driver issue) |
+| OVERLOAD | UPS load exceeds rated capacity |
+
+**Power states** (checked if no critical or warning state):
 
 | Flag | Meaning |
 |---|---|

--- a/ups-status.sh
+++ b/ups-status.sh
@@ -83,7 +83,7 @@ if [[ "$STATUS" == "SHUTTING DOWN" ]]; then
     FALLBACK_TEXT="$TEXT_ALERT"
 elif [[ "$STATUS" == *"COMMLOST"* ]]; then
     ALT="unknown"
-    CLASS="critical"
+    CLASS="warning"
     WARNING="COMMUNICATION LOST"
     FALLBACK_TEXT="$TEXT_UNKNOWN"
 elif [[ "$STATUS" == *"LOWBATT"* ]]; then
@@ -101,7 +101,7 @@ elif [[ "$STATUS" == *"NOBATT"* ]]; then
     FALLBACK_TEXT="$TEXT_ALERT"
 elif [[ "$STATUS" == *"OVERLOAD"* ]]; then
     ALT="alert"
-    CLASS="critical"
+    CLASS="warning"
     WARNING="UPS OVERLOADED"
 fi
 

--- a/ups-status.sh
+++ b/ups-status.sh
@@ -75,7 +75,7 @@ INFO_FLAGS=""
 [[ "$STATUS" == *"SLAVE"* && "$STATUS" != *"SLAVEDOWN"* ]] && INFO_FLAGS="${INFO_FLAGS}Running as slave. "
 [[ "$STATUS" == *"SLAVEDOWN"* ]] && INFO_FLAGS="${INFO_FLAGS}Slave not responding. "
 
-# Critical states (highest priority) - these override power state detection
+# Priority states (critical: SHUTTING DOWN, LOWBATT, REPLACEBATT, NOBATT; warning: COMMLOST, OVERLOAD)
 if [[ "$STATUS" == "SHUTTING DOWN" ]]; then
     ALT="alert"
     CLASS="critical"


### PR DESCRIPTION
## Summary

- `OVERLOAD` and `COMMLOST` moved from `critical` to `warning` CSS class in `ups-status.sh`
- Documentation updated in `CLAUDE.md` and `README.md` to reflect the new severity tier
- Guiding principle: **critical** = UPS hardware failing or shutdown imminent; **warning** = attention needed but UPS is healthy

## Changes

- **`ups-status.sh`**: `CLASS="critical"` → `CLASS="warning"` for `COMMLOST` and `OVERLOAD` branches; `ALT` values unchanged
- **`CLAUDE.md`**: Added explicit "Warning states" tier to the status handling priority list
- **`README.md`**: Updated CSS class condition table and status flags section to distinguish critical from warning states

## Test plan

- [x] Run `./ups-status.sh | python -m json.tool` to verify JSON output is still well-formed
- [x] Verify `class` field is `"warning"` (not `"critical"`) when simulating OVERLOAD or COMMLOST status

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reclassified OVERLOAD and COMMLOST from critical to warning so they no longer trigger highest-severity alerts; critical now focuses on imminent shutdown/hardware-failure conditions.
  * Adjusted status priority so power-state checks occur only when no critical or warning conditions apply.

* **Documentation**
  * Updated docs and UI text to reflect new critical/warning/power state hierarchy and tooltip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->