### PR TITLE
Add just-based lint/test workflow and UPS status refinements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Verify shell script syntax
-        run: bash -n ups-status.sh
+      - name: Install check tools
+        run: sudo apt-get update && sudo apt-get install -y just shellcheck
 
-      - name: Verify Python test syntax
-        run: python3 -m py_compile tests/test_ups_status.py
+      - name: Run lint checks
+        run: just lint
 
       - name: Run unit tests
-        run: python3 -m unittest discover -s tests -v
+        run: just test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,54 +12,15 @@ This file is the canonical agent guidance for this repository. `CLAUDE.md` deleg
 - User-facing docs: `README.md`
 - Release history: `CHANGELOG.md`
 
-The script runs `apcaccess status`, reads a small subset of fields, and emits Waybar JSON:
-
-```json
-{"text":"...","alt":"...","tooltip":"...","class":"...","percentage":42}
-```
-
-## Behavior Notes
-
-The script currently reads only these `apcaccess status` fields:
-
-- `STATUS`
-- `BCHARGE`
-- `LOADPCT`
-- `TIMELEFT`
-- `LINEV`
-
-`STATUS` may contain multiple flags. The resolver is context-aware:
-
-- Determine the primary power state first: `ONLINE`, `ONBATT`, or unknown
-- Apply warning and critical modifiers on top of that power state
-- Keep informational flags in the tooltip only
-
-Important expectations:
-
-- `ONLINE LOWBATT` is `warning` with the `charging` icon
-- `ONBATT LOWBATT` is `critical` with the `discharging` icon
-- `COMMLOST` uses the `unknown` icon
-- `SHUTTING DOWN` and `NOBATT` use the `alert` icon
+For installation, configuration, output fields, CSS classes, status behavior, and troubleshooting, use `README.md` as the source of truth.
 
 ## Testing
 
-Run the unit test suite with:
-
-```bash
-python3 -m unittest discover -s tests -v
-```
-
-CI runs the same suite plus basic syntax checks in GitHub Actions.
+Use the test and check commands documented in `README.md`.
 
 The tests mock `apcaccess` by prepending a temporary script to `PATH`. Keep tests focused on the actual script contract rather than refactoring the shell implementation into a separate library.
 
-When behavior changes, update or add tests for:
-
-- mixed `STATUS` combinations
-- power-state precedence
-- icon override precedence
-- fallback text for error and unknown conditions
-- tooltip warning and informational lines
+When behavior changes, update or add focused tests and keep `README.md` and `CHANGELOG.md` in sync.
 
 ## Documentation And Release Hygiene
 
@@ -72,7 +33,7 @@ Keep these files in sync with behavior changes:
 Use `CHANGELOG.md` like this:
 
 - Add ongoing work under `## [Unreleased]`
-- Move those entries into `0.2.0`, `0.2.1`, etc. when tagged
+- Move those entries into the next version section when preparing or tagging a release
 - Keep historical entries concise and user-facing
 
 ## APCUPSd Reference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-19
+
+### Changed
+
+- Added a `just` command surface for local lint, test, and full check runs.
+- Switched CI to run the shared `just` lint and test recipes.
+- Clarified installation docs for copying the script from a clone or release archive.
+- Added configurable on-battery charge thresholds via `WARNING_CHARGE` and `CRITICAL_CHARGE`.
+- Called `apcaccess` without an explicit `status` argument, matching its default action.
+- Reclassified `apcaccess` command failures and empty or malformed status output as critical while keeping `COMMLOST` as warning.
+- Kept `LOWBATT` critical when the UPS is on battery because apcupsd treats that state as shutdown-relevant.
+- Clamped numeric `BCHARGE` readings into the 0-100 range while skipping charge-threshold checks for missing or nonnumeric charge data.
+
+### Fixed
+
+- Escaped JSON output more completely, including backslashes, control characters, literal Unicode escape sequences, and multibyte text.
+- Parsed required `apcaccess` fields in one pass while preserving values containing colons.
+
 ## [0.2.0] - 2026-04-06
 
 ### Added
@@ -65,7 +83,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tooltips showing UPS status, charge, load, runtime, and line voltage.
 - Manual and signal-driven Waybar refresh instructions in the README.
 
-[Unreleased]: https://github.com/viell-dev/waybar-apcupsd/compare/0.2.0...HEAD
+[Unreleased]: https://github.com/viell-dev/waybar-apcupsd/compare/0.3.0...HEAD
+[0.3.0]: https://github.com/viell-dev/waybar-apcupsd/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/viell-dev/waybar-apcupsd/compare/0.1.3...0.2.0
 [0.1.3]: https://github.com/viell-dev/waybar-apcupsd/compare/0.1.2...0.1.3
 [0.1.2]: https://github.com/viell-dev/waybar-apcupsd/compare/0.1.1...0.1.2

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/github/v/release/viell-dev/waybar-apcupsd)](https://github.com/viell-dev/waybar-apcupsd/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE-MIT)
 
-A custom [Waybar](https://github.com/Alexays/Waybar) module for monitoring an APC UPS via [apcupsd](http://www.apcupsd.org/). Displays battery-style icons with color-coded status.
+A custom [Waybar](https://github.com/Alexays/Waybar) module for monitoring an APC UPS via [apcupsd](https://sourceforge.net/projects/apcupsd/). Displays battery-style icons with color-coded status.
 
 Release notes live in [CHANGELOG.md](CHANGELOG.md).
 
@@ -15,17 +15,21 @@ Release notes live in [CHANGELOG.md](CHANGELOG.md).
 Verify your UPS is communicating:
 
 ```bash
-apcaccess status
+apcaccess
 ```
 
 ## Installation
 
-### 1. Clone the repository
+### 1. Install the script
 
 ```bash
-git clone https://github.com/viell-dev/waybar-apcupsd.git
-chmod +x waybar-apcupsd/ups-status.sh
+cp ups-status.sh /path/to/ups-status.sh
+chmod +x /path/to/ups-status.sh
 ```
+
+Install the script wherever you keep Waybar helper scripts. You can copy
+`ups-status.sh` from a cloned repository or from a release archive. The examples
+below use `/path/to/ups-status.sh`; replace it with your chosen location.
 
 ### 2. Add the module to your Waybar config
 
@@ -35,11 +39,11 @@ In your Waybar config (e.g. `~/.config/waybar/config.jsonc`), add `"custom/ups"`
 "modules-right": ["custom/ups", ...],
 ```
 
-Then add the module definition, pointing `exec` at wherever you cloned the script:
+Then add the module definition, pointing `exec` at the installed script:
 
 ```jsonc
 "custom/ups": {
-  "exec": "/path/to/waybar-apcupsd/ups-status.sh",
+  "exec": "/path/to/ups-status.sh",
   "return-type": "json",
   "interval": 60,
   "signal": 9,
@@ -106,7 +110,10 @@ Icons are configured entirely in your Waybar config via [`format-icons`](https:/
 
 ### Using different icons
 
-Replace the icons in `format-icons` in your Waybar config. Arrays must have entries from low to high — Waybar picks the icon based on the `percentage` value.
+Replace the icons in `format-icons` in your Waybar config. Arrays must be
+ordered from low to high charge. Waybar maps the script's `percentage` value
+across however many entries you provide, so you can use a coarse set such as 5
+icons or a finer set such as 11 icons.
 
 ```jsonc
 "format-icons": {
@@ -118,19 +125,9 @@ Replace the icons in `format-icons` in your Waybar config. Arrays must have entr
 }
 ```
 
-### Using text instead of icons
-
-Set `format-icons` to text labels for a setup that doesn't require a Nerd Font:
-
-```jsonc
-"format": "{icon} {text}",
-"format-icons": {
-  "charging": "CHG",
-  "discharging": "BAT",
-  "alert": "ALT",
-  "unknown": "UNK"
-}
-```
+The icon strings can be plain text labels if you do not use a Nerd Font. Keep
+`charging` and `discharging` as arrays when you want Waybar to select by
+percentage.
 
 ### Hiding the icon
 
@@ -154,7 +151,8 @@ pkill -SIGRTMIN+9 waybar 2>/dev/null
 ```
 
 This sends a signal to Waybar to immediately re-run the UPS script. These are
-system files owned by root and may be overwritten on apcupsd package updates.
+root-owned, package-managed system files, so keep local changes in mind when
+updating the distro package.
 
 You can also trigger a manual refresh at any time:
 
@@ -168,20 +166,49 @@ The script outputs JSON with these fields:
 
 | Field | Description | Example |
 |---|---|---|
-| `text` | Battery percentage, or status text for errors | `"75%"` |
+| `text` | Battery percentage, or fallback status text | `"75%"` |
 | `alt` | State name for icon selection | `"charging"` |
 | `tooltip` | Detailed UPS info | `"Status: ONLINE\n..."` |
 | `class` | CSS class for styling | `"online"` |
 | `percentage` | Battery charge (0-100) | `100` |
+
+Numeric `BCHARGE` values are clamped into the `0-100` range before output, so
+minor over-100 readings from UPS rounding are treated as full charge. If
+`BCHARGE` is missing or nonnumeric, the script reports `text: "Unknown"` and
+`percentage: 0`, but it does not apply charge-threshold warning or critical
+classes from that placeholder value.
 
 ### CSS Classes
 
 | CSS Class | Condition |
 |---|---|
 | `online` | On mains power |
-| `on-battery` | On battery, charge > 50% |
-| `warning` | On battery charge 20-50%; communication or hardware warnings; `ONLINE LOWBATT` |
-| `critical` | On battery charge < 20%; `ONBATT LOWBATT`; `NOBATT`; `SHUTTING DOWN` |
+| `on-battery` | On battery, above configured warning/critical charge thresholds |
+| `warning` | On battery at or below `WARNING_CHARGE`; `COMMLOST`; hardware warnings; `ONLINE LOWBATT` |
+| `critical` | `SHUTTING DOWN`; `NOBATT`; `ONBATT LOWBATT`; `apcaccess` failure; empty `apcaccess` output; on battery at or below configured `CRITICAL_CHARGE` |
+
+### Charge Thresholds
+
+Charge-level CSS classes are configurable with environment variables:
+
+| Variable | Default | Meaning |
+|---|---:|---|
+| `WARNING_CHARGE` | `20` | On-battery charge at or below this percentage becomes `warning`; use an integer from `0` to `100`; `0` disables the warning threshold |
+| `CRITICAL_CHARGE` | `0` | On-battery charge at or below this percentage becomes `critical`; use an integer from `0` to `100`; `0` disables the critical threshold |
+
+If both thresholds are enabled, `CRITICAL_CHARGE` must be lower than
+`WARNING_CHARGE`. Invalid threshold config emits a critical `Error` payload so
+the Waybar module makes the misconfiguration visible.
+
+Examples:
+
+```jsonc
+// Warn at 30%, never make charge level alone critical
+"exec": "WARNING_CHARGE=30 /path/to/ups-status.sh"
+
+// Use only a critical threshold
+"exec": "WARNING_CHARGE=0 CRITICAL_CHARGE=20 /path/to/ups-status.sh"
+```
 
 ### Status Flags
 
@@ -189,7 +216,7 @@ The apcupsd STATUS field can contain multiple space-separated flags (e.g., `ONLI
 
 `LOWBATT` is context-sensitive:
 
-- `ONBATT LOWBATT` stays critical because shutdown is imminent
+- `ONBATT LOWBATT` is critical because apcupsd treats the low-battery bit as a shutdown trigger while on battery
 - `ONLINE LOWBATT` is downgraded to a warning and keeps the normal charging icon
 
 **Critical states** (shutdown imminent or battery missing):
@@ -230,6 +257,13 @@ The apcupsd STATUS field can contain multiple space-separated flags (e.g., `ONLI
 | SLAVE | Running as network slave |
 | SLAVEDOWN | Slave not responding |
 
+`COMMLOST` is treated as a warning. Some UPS models briefly stop reporting
+status during self-tests, so `COMMLOST` is treated as a temporary communication
+warning rather than a critical alert. If `apcaccess` itself exits with an error,
+or exits successfully without returning status data, the script reports a
+critical `Error` because that usually means apcupsd is not running, the local
+query path is misconfigured, or apcupsd returned an unexpected result.
+
 ### Tooltip
 
 Hovering shows detailed info:
@@ -251,26 +285,14 @@ Warning messages (⚠) and informational messages (ℹ) appear at the top of the
 systemctl status apcupsd
 
 # Test apcaccess directly
-apcaccess status
+apcaccess
 
 # Test the script output (should print valid JSON)
-/path/to/waybar-apcupsd/ups-status.sh
+/path/to/ups-status.sh
 
 # Validate JSON
-/path/to/waybar-apcupsd/ups-status.sh | python -m json.tool
+/path/to/ups-status.sh | python -m json.tool
 ```
-
-## Tests
-
-The test suite mocks `apcaccess` via `PATH` and only emits the fields this script reads: `STATUS`, `BCHARGE`, `LOADPCT`, `TIMELEFT`, and `LINEV`.
-
-```bash
-python3 -m unittest discover -s tests
-```
-
-This requires Python 3, but does not require a running UPS or `apcupsd`.
-
-The same checks run in GitHub Actions on pushes to `main` and on pull requests.
 
 ### Debug logging
 
@@ -286,12 +308,30 @@ Logs are written to `/tmp/waybar-apcupsd.log` (override with `DEBUG_LOG`).
 
 ```bash
 # Enable logging for unknown statuses in Waybar config
-"exec": "DEBUG=1 /path/to/waybar-apcupsd/ups-status.sh"
+"exec": "DEBUG=1 /path/to/ups-status.sh"
 
 # Or test manually with full logging
-DEBUG=2 /path/to/waybar-apcupsd/ups-status.sh
+DEBUG=2 /path/to/ups-status.sh
 cat /tmp/waybar-apcupsd.log
 ```
+
+## Tests
+
+The test suite mocks `apcaccess` via `PATH` and only emits the fields this script reads: `STATUS`, `BCHARGE`, `LOADPCT`, `TIMELEFT`, and `LINEV`.
+
+```bash
+just test
+```
+
+This requires `just` and Python 3, but does not require a running UPS or `apcupsd`.
+
+Run the full local check suite with:
+
+```bash
+just check
+```
+
+The same lint and test checks run in GitHub Actions on pushes to `main` and on pull requests.
 
 ## AI Disclaimer
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,14 @@
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+default:
+    just --list
+
+lint:
+    bash -n ups-status.sh
+    shellcheck ups-status.sh
+    python3 -m py_compile tests/test_ups_status.py
+
+test:
+    python3 -m unittest discover -s tests -v
+
+check: lint test

--- a/tests/test_ups_status.py
+++ b/tests/test_ups_status.py
@@ -41,6 +41,7 @@ class UpsStatusTestCase(unittest.TestCase):
         *,
         apcaccess_output=None,
         apcaccess_exit_code=0,
+        apcaccess_stderr=None,
         extra_env=None,
         capture_debug_log=False,
     ):
@@ -48,9 +49,11 @@ class UpsStatusTestCase(unittest.TestCase):
             temp_path = Path(temp_dir)
             mock_apcaccess = temp_path / "apcaccess"
             mock_output = temp_path / "apcaccess-status.txt"
+            mock_error = temp_path / "apcaccess-stderr.txt"
             debug_log = temp_path / "debug.log"
             payload = apcaccess_output or ""
             mock_output.write_text(payload)
+            mock_error.write_text(apcaccess_stderr or "")
 
             mock_apcaccess.write_text(
                 textwrap.dedent(
@@ -58,11 +61,12 @@ class UpsStatusTestCase(unittest.TestCase):
                     #!/usr/bin/env bash
                     set -euo pipefail
 
-                    if [[ "${{1:-}}" != "status" ]]; then
+                    if [[ "$#" -ne 0 ]]; then
                         exit 1
                     fi
 
                     if [[ "{apcaccess_exit_code}" -ne 0 ]]; then
+                        cat "{mock_error}" >&2
                         exit "{apcaccess_exit_code}"
                     fi
 
@@ -88,6 +92,7 @@ class UpsStatusTestCase(unittest.TestCase):
                 check=True,
             )
 
+            self.assertEqual(result.stderr, "")
             data = json.loads(result.stdout)
             debug_output = debug_log.read_text() if debug_log.exists() else ""
 
@@ -103,8 +108,9 @@ class UpsStatusTestCase(unittest.TestCase):
         expected_alt,
         expected_text,
         tooltip_contains=(),
+        extra_env=None,
     ):
-        data = self.run_module(apcaccess_output=status_output)
+        data = self.run_module(apcaccess_output=status_output, extra_env=extra_env)
 
         self.assertEqual(data["class"], expected_class)
         self.assertEqual(data["alt"], expected_alt)
@@ -129,21 +135,77 @@ class UpsStatusTestCase(unittest.TestCase):
             expected_text="80%",
         )
 
-    def test_on_battery_warning_threshold(self):
+    def test_on_battery_above_default_warning_threshold(self):
+        self.assert_status(
+            status_output=build_status_output(status="ONBATT", bcharge="45.0 Percent"),
+            expected_class="on-battery",
+            expected_alt="discharging",
+            expected_text="45%",
+        )
+
+    def test_on_battery_default_warning_threshold(self):
+        self.assert_status(
+            status_output=build_status_output(status="ONBATT", bcharge="15.0 Percent"),
+            expected_class="warning",
+            expected_alt="discharging",
+            expected_text="15%",
+            tooltip_contains=("Battery charge at or below warning threshold",),
+        )
+
+    def test_on_battery_missing_charge_does_not_trigger_charge_threshold(self):
+        self.assert_status(
+            status_output=build_status_output(status="ONBATT", bcharge=""),
+            expected_class="on-battery",
+            expected_alt="discharging",
+            expected_text="Unknown",
+            tooltip_contains=("Battery charge unavailable.", "Battery: unavailable"),
+        )
+
+    def test_on_battery_invalid_charge_does_not_trigger_charge_threshold(self):
+        self.assert_status(
+            status_output=build_status_output(status="ONBATT", bcharge="N/A"),
+            expected_class="on-battery",
+            expected_alt="discharging",
+            expected_text="Unknown",
+            tooltip_contains=("Battery charge unavailable.", "Battery: N/A"),
+        )
+
+    def test_on_battery_charge_above_100_is_clamped_to_full(self):
+        self.assert_status(
+            status_output=build_status_output(status="ONBATT", bcharge="101.0 Percent"),
+            expected_class="on-battery",
+            expected_alt="discharging",
+            expected_text="100%",
+            tooltip_contains=("Battery: 100%"),
+        )
+
+    def test_on_battery_negative_charge_is_clamped_to_empty(self):
+        self.assert_status(
+            status_output=build_status_output(status="ONBATT", bcharge="-1.0 Percent"),
+            expected_class="warning",
+            expected_alt="discharging",
+            expected_text="0%",
+            tooltip_contains=("Battery charge at or below warning threshold", "Battery: 0%"),
+        )
+
+    def test_on_battery_configurable_warning_threshold(self):
         self.assert_status(
             status_output=build_status_output(status="ONBATT", bcharge="45.0 Percent"),
             expected_class="warning",
             expected_alt="discharging",
             expected_text="45%",
+            tooltip_contains=("Battery charge at or below warning threshold",),
+            extra_env={"WARNING_CHARGE": "50"},
         )
 
-    def test_on_battery_critical_threshold(self):
+    def test_on_battery_configurable_critical_threshold(self):
         self.assert_status(
-            status_output=build_status_output(status="ONBATT", bcharge="15.0 Percent"),
+            status_output=build_status_output(status="ONBATT", bcharge="45.0 Percent"),
             expected_class="critical",
             expected_alt="discharging",
-            expected_text="15%",
-            tooltip_contains=("LOW BATTERY",),
+            expected_text="45%",
+            tooltip_contains=("Battery charge at or below critical threshold",),
+            extra_env={"WARNING_CHARGE": "0", "CRITICAL_CHARGE": "50"},
         )
 
     def test_on_battery_lowbatt_is_shutdown_imminent(self):
@@ -236,6 +298,86 @@ class UpsStatusTestCase(unittest.TestCase):
             tooltip_contains=("Unknown status flag(s): MYSTERY",),
         )
 
+    def test_blank_status_field_is_reported_as_unknown_status(self):
+        self.assert_status(
+            status_output=build_status_output(status="", bcharge="66.0 Percent"),
+            expected_class="warning",
+            expected_alt="unknown",
+            expected_text="Unknown",
+            tooltip_contains=("Unknown status: <empty>", "Status: "),
+        )
+
+    def test_missing_status_field_returns_critical_payload(self):
+        status_output = textwrap.dedent(
+            """\
+            BCHARGE  : 66.0 Percent
+            LOADPCT  : 12.0 Percent
+            TIMELEFT : 45.0 Minutes
+            LINEV    : 230.0 Volts
+            """
+        )
+
+        data = self.run_module(apcaccess_output=status_output)
+
+        self.assertEqual(data["text"], "Error")
+        self.assertEqual(data["alt"], "alert")
+        self.assertEqual(data["class"], "critical")
+        self.assertEqual(data["percentage"], 0)
+        self.assertIn("missing STATUS field", data["tooltip"])
+
+    def test_status_text_with_json_metacharacters_is_escaped(self):
+        status = 'MYSTERY"FLAG\\PATH'
+
+        self.assert_status(
+            status_output=build_status_output(status=status, bcharge="66.0 Percent"),
+            expected_class="warning",
+            expected_alt="unknown",
+            expected_text="Unknown",
+            tooltip_contains=(f"Unknown status flag(s): {status}", f"Status: {status}"),
+        )
+
+    def test_status_text_with_literal_unicode_escape_sequence_is_escaped(self):
+        status = r"MYSTERY\u26A0"
+
+        self.assert_status(
+            status_output=build_status_output(status=status, bcharge="66.0 Percent"),
+            expected_class="warning",
+            expected_alt="unknown",
+            expected_text="Unknown",
+            tooltip_contains=(f"Unknown status flag(s): {status}", f"Status: {status}"),
+        )
+
+    def test_status_text_with_multibyte_unicode_is_preserved(self):
+        status = "MYSTERY⚠é😀"
+
+        self.assert_status(
+            status_output=build_status_output(status=status, bcharge="66.0 Percent"),
+            expected_class="warning",
+            expected_alt="unknown",
+            expected_text="Unknown",
+            tooltip_contains=(f"Unknown status flag(s): {status}", f"Status: {status}"),
+        )
+
+    def test_status_text_with_control_character_uses_unicode_escape(self):
+        status = "MYSTERY\x1fFLAG"
+
+        self.assert_status(
+            status_output=build_status_output(status=status, bcharge="66.0 Percent"),
+            expected_class="warning",
+            expected_alt="unknown",
+            expected_text="Unknown",
+            tooltip_contains=(f"Unknown status flag(s): {status}", f"Status: {status}"),
+        )
+
+    def test_field_values_may_contain_colons(self):
+        self.assert_status(
+            status_output=build_status_output(status="VENDOR:FLAG", bcharge="66.0 Percent"),
+            expected_class="warning",
+            expected_alt="unknown",
+            expected_text="Unknown",
+            tooltip_contains=("Unknown status flag(s): VENDOR:FLAG", "Status: VENDOR:FLAG"),
+        )
+
     def test_status_whitespace_and_padded_charge_are_normalized(self):
         self.assert_status(
             status_output=build_status_output(
@@ -261,19 +403,65 @@ class UpsStatusTestCase(unittest.TestCase):
             ),
         )
 
-    def test_apcaccess_failure_returns_error_payload(self):
-        data = self.run_module(apcaccess_exit_code=1)
+    def test_apcaccess_failure_returns_critical_payload(self):
+        data = self.run_module(
+            apcaccess_exit_code=1,
+            apcaccess_stderr="Error contacting apcupsd @ localhost:3551: Connection refused\n",
+        )
+
+        self.assertEqual(data["text"], "Error")
+        self.assertEqual(data["alt"], "alert")
+        self.assertEqual(data["class"], "critical")
+        self.assertEqual(data["percentage"], 0)
+        self.assertIn("UPS: Cannot query apcupsd", data["tooltip"])
+        self.assertIn("Error contacting apcupsd", data["tooltip"])
+
+    def test_empty_apcaccess_output_returns_critical_payload(self):
+        data = self.run_module(apcaccess_output="")
 
         self.assertEqual(
             data,
             {
                 "text": "Error",
                 "alt": "alert",
-                "tooltip": "UPS: Cannot communicate with apcupsd",
+                "tooltip": "UPS: apcaccess returned no status data",
                 "class": "critical",
                 "percentage": 0,
             },
         )
+
+    def test_non_numeric_charge_threshold_config_returns_error_payload(self):
+        data = self.run_module(
+            apcaccess_output=build_status_output(status="ONLINE"),
+            extra_env={"WARNING_CHARGE": "soon"},
+        )
+
+        self.assertEqual(data["text"], "Error")
+        self.assertEqual(data["alt"], "alert")
+        self.assertEqual(data["class"], "critical")
+        self.assertIn("Invalid charge threshold config", data["tooltip"])
+
+    def test_out_of_range_charge_threshold_config_returns_error_payload(self):
+        data = self.run_module(
+            apcaccess_output=build_status_output(status="ONLINE"),
+            extra_env={"WARNING_CHARGE": "101"},
+        )
+
+        self.assertEqual(data["text"], "Error")
+        self.assertEqual(data["alt"], "alert")
+        self.assertEqual(data["class"], "critical")
+        self.assertIn("integers from 0 to 100", data["tooltip"])
+
+    def test_overlapping_charge_threshold_config_returns_error_payload(self):
+        data = self.run_module(
+            apcaccess_output=build_status_output(status="ONLINE"),
+            extra_env={"WARNING_CHARGE": "20", "CRITICAL_CHARGE": "20"},
+        )
+
+        self.assertEqual(data["text"], "Error")
+        self.assertEqual(data["alt"], "alert")
+        self.assertEqual(data["class"], "critical")
+        self.assertIn("CRITICAL_CHARGE must be lower than WARNING_CHARGE", data["tooltip"])
 
     def test_unknown_status_debug_level_two_logs_once(self):
         _, debug_output = self.run_module(

--- a/ups-status.sh
+++ b/ups-status.sh
@@ -29,24 +29,122 @@ TEXT_ERROR="Error"
 TEXT_ALERT="Alert"
 TEXT_UNKNOWN="Unknown"
 
-# --- Fetch all fields in one call -----------------------------------------
+# --- Charge threshold settings -------------------------------------------
+# 0 disables the corresponding threshold.
+WARNING_CHARGE=${WARNING_CHARGE:-20}
+CRITICAL_CHARGE=${CRITICAL_CHARGE:-0}
 
-RAW=$(apcaccess status 2>/dev/null) || RAW=""
+json_escape() {
+    local value=$1
+    local char
+    local code_hex
+    local escape
+    local code
 
-if [[ -z "$RAW" ]]; then
-    printf '{"text": "%s", "alt": "alert", "tooltip": "UPS: Cannot communicate with apcupsd", "class": "critical", "percentage": 0}\n' "$TEXT_ERROR"
+    value=${value//\\/\\\\}
+    value=${value//\"/\\\"}
+    value=${value//$'\b'/\\b}
+    value=${value//$'\f'/\\f}
+    value=${value//$'\n'/\\n}
+    value=${value//$'\r'/\\r}
+    value=${value//$'\t'/\\t}
+
+    for code in {1..31}; do
+        case "$code" in
+            8|9|10|12|13)
+                continue
+                ;;
+        esac
+
+        printf -v code_hex "%02x" "$code"
+        printf -v char "%b" "\\x$code_hex"
+        printf -v escape '\\u%04x' "$code"
+        value=${value//"$char"/"$escape"}
+    done
+
+    printf '%s' "$value"
+}
+
+emit_error() {
+    local tooltip=$1
+    local text
+
+    text=$(json_escape "$TEXT_ERROR")
+    tooltip=$(json_escape "$tooltip")
+    printf '{"text": "%s", "alt": "alert", "tooltip": "%s", "class": "critical", "percentage": 0}\n' "$text" "$tooltip"
+}
+
+if [[ ! "$WARNING_CHARGE" =~ ^[0-9]{1,3}$ || ! "$CRITICAL_CHARGE" =~ ^[0-9]{1,3}$ ]]; then
+    emit_error "UPS: Invalid charge threshold config. WARNING_CHARGE and CRITICAL_CHARGE must be integers from 0 to 100."
     exit 0
 fi
 
-get_field() {
-    echo "$RAW" | awk -F': ' -v key="$1" '$1 ~ "^"key" *$" { gsub(/^ +| +$/, "", $2); print $2; exit }'
-}
+WARNING_CHARGE=$((10#$WARNING_CHARGE))
+CRITICAL_CHARGE=$((10#$CRITICAL_CHARGE))
 
-STATUS=$(get_field STATUS)
-BCHARGE=$(get_field BCHARGE)
-LOADPCT=$(get_field LOADPCT)
-TIMELEFT=$(get_field TIMELEFT)
-LINEV=$(get_field LINEV)
+if (( WARNING_CHARGE > 100 || CRITICAL_CHARGE > 100 )); then
+    emit_error "UPS: Invalid charge threshold config. WARNING_CHARGE and CRITICAL_CHARGE must be integers from 0 to 100."
+    exit 0
+fi
+
+if (( WARNING_CHARGE != 0 && CRITICAL_CHARGE >= WARNING_CHARGE )); then
+    emit_error "UPS: Invalid charge threshold config. CRITICAL_CHARGE must be lower than WARNING_CHARGE, or WARNING_CHARGE must be 0."
+    exit 0
+fi
+
+# --- Fetch all fields in one call -----------------------------------------
+
+if ! RAW=$(apcaccess 2>&1); then
+    APCACCESS_ERROR=$RAW
+    RAW=""
+else
+    APCACCESS_ERROR=""
+fi
+
+if [[ -z "$RAW" ]]; then
+    if [[ -n "$APCACCESS_ERROR" ]]; then
+        emit_error "UPS: Cannot query apcupsd"$'\n'"${APCACCESS_ERROR}"
+        exit 0
+    fi
+
+    emit_error "UPS: apcaccess returned no status data"
+    exit 0
+fi
+
+STATUS=""
+BCHARGE=""
+LOADPCT=""
+TIMELEFT=""
+LINEV=""
+HAS_STATUS_FIELD=0
+
+while IFS=$'\t' read -r key value; do
+    case "$key" in
+        STATUS)
+            STATUS=$value
+            HAS_STATUS_FIELD=1
+            ;;
+        BCHARGE) BCHARGE=$value ;;
+        LOADPCT) LOADPCT=$value ;;
+        TIMELEFT) TIMELEFT=$value ;;
+        LINEV) LINEV=$value ;;
+    esac
+done < <(
+    awk -F':' '
+        $1 ~ /^ *(STATUS|BCHARGE|LOADPCT|TIMELEFT|LINEV) *$/ {
+            key = $1
+            value = substr($0, index($0, ":") + 1)
+            gsub(/^ +| +$/, "", key)
+            gsub(/^ +| +$/, "", value)
+            print key "\t" value
+        }
+    ' <<< "$RAW"
+)
+
+if (( HAS_STATUS_FIELD == 0 )); then
+    emit_error "UPS: apcaccess returned malformed status data (missing STATUS field)"
+    exit 0
+fi
 
 # Strip units (e.g. "100.0 Percent" -> "100.0")
 BCHARGE=${BCHARGE%% *}
@@ -55,12 +153,20 @@ TIMELEFT=${TIMELEFT%% *}
 LINEV=${LINEV%% *}
 
 # Integer charge for percentage output
-CHARGE_INT=${BCHARGE%%.*}
-CHARGE_INT=${CHARGE_INT//[^0-9]/}
-if [[ -n "$CHARGE_INT" ]]; then
-    CHARGE_INT=$((10#$CHARGE_INT))
-else
-    CHARGE_INT=0
+CHARGE_RAW=$BCHARGE
+CHARGE_INT=0
+CHARGE_VALID=0
+if [[ "$BCHARGE" =~ ^-?[0-9]+([.][0-9]+)?$ ]]; then
+    CHARGE_INT=${BCHARGE%%.*}
+    CHARGE_VALID=1
+    if [[ "$CHARGE_INT" == -* ]]; then
+        CHARGE_INT=0
+    else
+        CHARGE_INT=$((10#$CHARGE_INT))
+        if (( CHARGE_INT > 100 )); then
+            CHARGE_INT=100
+        fi
+    fi
 fi
 
 # --- Determine state from compound STATUS field --------------------------
@@ -166,13 +272,12 @@ fi
 if has_flag ONBATT; then
     POWER_STATE="on-battery"
     ALT="discharging"
-    if (( CHARGE_INT <= 20 )); then
+    if (( CHARGE_VALID == 1 && CRITICAL_CHARGE != 0 && CHARGE_INT <= CRITICAL_CHARGE )); then
         CLASS="critical"
-        if ! has_flag LOWBATT; then
-            WARNINGS+=("LOW BATTERY")
-        fi
-    elif (( CHARGE_INT <= 50 )); then
+        WARNINGS+=("Battery charge at or below critical threshold")
+    elif (( CHARGE_VALID == 1 && WARNING_CHARGE != 0 && CHARGE_INT <= WARNING_CHARGE )); then
         CLASS="warning"
+        WARNINGS+=("Battery charge at or below warning threshold")
     else
         CLASS="on-battery"
     fi
@@ -253,6 +358,10 @@ elif [[ "$POWER_STATE" == "unknown" && "$HAS_KNOWN_FLAG" -eq 0 ]]; then
     [[ "$DEBUG" -eq 1 ]] && debug_log
 fi
 
+if (( CHARGE_VALID == 0 )); then
+    INFO_MESSAGES+=("Battery charge unavailable.")
+fi
+
 if [[ -n "$ALT_OVERRIDE" ]]; then
     ALT=$ALT_OVERRIDE
 fi
@@ -262,22 +371,48 @@ fi
 
 # --- Build output ---------------------------------------------------------
 
-TEXT="${FALLBACK_TEXT:-${CHARGE_INT}%}"
+if [[ -n "$FALLBACK_TEXT" ]]; then
+    TEXT=$FALLBACK_TEXT
+elif (( CHARGE_VALID == 1 )); then
+    TEXT="${CHARGE_INT}%"
+else
+    TEXT="$TEXT_UNKNOWN"
+fi
+
+TOOLTIP=""
+
+append_tooltip_line() {
+    local line=$1
+
+    if [[ -n "$TOOLTIP" ]]; then
+        TOOLTIP+=$'\n'
+    fi
+
+    TOOLTIP+="$line"
+}
 
 # Tooltip with full details
 # Note: ⚠ is U+26A0 (Warning Sign), ℹ is U+2139 (Information Source)
-TOOLTIP=""
 for warning in "${WARNINGS[@]}"; do
-    TOOLTIP="${TOOLTIP}⚠ ${warning}\n"
+    append_tooltip_line "⚠ ${warning}"
 done
 for info in "${INFO_MESSAGES[@]}"; do
-    TOOLTIP="${TOOLTIP}ℹ ${info}\n"
+    append_tooltip_line "ℹ ${info}"
 done
-TOOLTIP="${TOOLTIP}Status: ${STATUS}\nBattery: ${BCHARGE}%\nLoad: ${LOADPCT}%\nRuntime: ${TIMELEFT} min\nLine: ${LINEV} V"
+append_tooltip_line "Status: ${STATUS}"
+if (( CHARGE_VALID == 1 )); then
+    append_tooltip_line "Battery: ${CHARGE_INT}%"
+elif [[ -n "$CHARGE_RAW" ]]; then
+    append_tooltip_line "Battery: ${CHARGE_RAW}"
+else
+    append_tooltip_line "Battery: unavailable"
+fi
+append_tooltip_line "Load: ${LOADPCT}%"
+append_tooltip_line "Runtime: ${TIMELEFT} min"
+append_tooltip_line "Line: ${LINEV} V"
 
-# Escape quotes for JSON
-TEXT="${TEXT//\"/\\\"}"
-TOOLTIP="${TOOLTIP//\"/\\\"}"
+TEXT=$(json_escape "$TEXT")
+TOOLTIP=$(json_escape "$TOOLTIP")
 
 printf '{"text": "%s", "alt": "%s", "tooltip": "%s", "class": "%s", "percentage": %d}\n' \
     "$TEXT" "$ALT" "$TOOLTIP" "$CLASS" "$CHARGE_INT"


### PR DESCRIPTION
## Summary
- Add a `just` command surface for local lint, test, and combined check runs, and switch CI to use those shared recipes.
- Expand the UPS script behavior to support configurable charge thresholds, better error handling, and more complete JSON escaping.
- Update the README and changelog to reflect the new install flow, status semantics, and testing commands.
- Add coverage for the new threshold logic, malformed output handling, and escaping edge cases.

## Testing
- `just lint`
- `just test`
- CI runs the same shared lint and test commands via GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable UPS charge warning/critical thresholds; improved error/tooltip reporting and JSON-safe output.

* **Bug Fixes**
  * More robust status parsing, clearer severity classification (warning vs critical), and safer escaping for displayed text.

* **Documentation**
  * Updated installation, usage, testing, and troubleshooting guidance; consolidated behavioral notes to a single source.

* **Tests**
  * Expanded tests for thresholds, status edge cases, and error paths.

* **Chores**
  * Added task automation and CI tasks to standardize linting and test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/viell-dev/waybar-apcupsd/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->